### PR TITLE
Apply lints and fix skipped line bug

### DIFF
--- a/src/directory_construction.rs
+++ b/src/directory_construction.rs
@@ -3,11 +3,10 @@ use std::{fs, path::PathBuf};
 
 pub fn build_fs_tree(fs_tree: Vec<PathBuf>) -> (std::io::Result<()>, String) {
     for path in fs_tree {
-        
         //Recursively create directories
         let result = fs::create_dir_all(path.as_path());
         if result.is_err() {
-            return (result, path.to_str().unwrap().to_owned())
+            return (result, path.to_str().unwrap().to_owned());
         }
     }
     (Ok(()), "completed without detecting errors".to_owned())

--- a/src/file_checks.rs
+++ b/src/file_checks.rs
@@ -7,41 +7,41 @@ const INVALID_FS_CHARS: &str = "<>:\"/\\|?*"; //characters forbidden in a window
 #[cfg(target_os = "macos")]
 const INVALID_FS_CHARS: &str = ":/"; //characters forbidden in a macos folder or file name and for this program.
 
-
-pub fn is_valid_file(file: &String) -> bool{
-
+pub fn is_valid_file(file: &str) -> bool {
     //strip and clean program specific chars.
     let file_lines: Vec<String> = file.split('\n').map(|x| x.to_owned()).collect();
     let file_lines: Vec<String> = file_lines.iter().map(|x| x.trim().to_owned()).collect();
 
     //check for invalid file syntax
     if !is_valid_syntax(&file_lines) {
-        return false
+        return false;
     }
     true
 }
 
 ///Check for program specific rule violations as discussed in the program instructions.
 fn is_valid_syntax(files_lines: &Vec<String>) -> bool {
-
     let mut current_line_num: usize = 0;
     let mut cleaned_file_lines: Vec<String> = Vec::with_capacity(files_lines.len());
-    
+
     for (index, line) in files_lines.iter().enumerate() {
         let mut new_line_num: usize = 0;
         for chr in line.chars() {
-               if chr == '/' {
-                   new_line_num += 1;
-               }else {
-                   break;
-               }
-           }
+            if chr == '/' {
+                new_line_num += 1;
+            } else {
+                break;
+            }
+        }
 
         //check to make sure that the user did not try to increase folder depth by more than one at a time (going from "/example" to "///example3").
-        if current_line_num+1 < new_line_num {
+        if current_line_num + 1 < new_line_num {
             let index = index + 1;
-            eprintln!("Invalid Syntax: Attempted to increase folder depth by more than 1 on line -> {}", index);
-            return false
+            eprintln!(
+                "Invalid Syntax: Attempted to increase folder depth by more than 1 on line -> {}",
+                index
+            );
+            return false;
         }
         current_line_num = new_line_num;
         cleaned_file_lines.push(line[new_line_num..].to_owned());
@@ -49,24 +49,22 @@ fn is_valid_syntax(files_lines: &Vec<String>) -> bool {
 
     //check if the remain string (stripped of the program specific syntax) contains illegal characters.
     if contains_invalid_chars(&cleaned_file_lines) {
-        return false
+        return false;
     };
     true
 }
 
-fn contains_invalid_chars(cleaned_file: &Vec<String>) -> bool {
-    
+fn contains_invalid_chars(cleaned_file: &[String]) -> bool {
     for (index, line) in cleaned_file.iter().enumerate() {
         for chr in INVALID_FS_CHARS.chars() {
             if line.contains(chr) {
                 let index = index + 1;
                 eprintln!("Invalid Character: illegal file system character detected!\n>Line: {index}\n>Character: \"{chr}\"");
-                return true
+                return true;
             }
         }
     }
-    
-    
+
     false
 }
 

--- a/src/file_parse.rs
+++ b/src/file_parse.rs
@@ -29,11 +29,6 @@ impl Build for DirectoryPaths {
         current_path.push(root_dir);
         let mut current_depth: isize = -1;
 
-        //remove the last element of the file variable and render file variable immutable.
-        let mut file = file.to_owned();
-        file.pop();
-        let file = file;
-
         for line in file {
             //check depth of the line
             //

--- a/src/file_parse.rs
+++ b/src/file_parse.rs
@@ -1,78 +1,77 @@
 use std::{path::PathBuf, usize};
 
-
 pub trait Build {
-    fn new(size: usize) -> DirectoryPaths;
-    fn parse<'a>(file: &'a Vec<String>, root_dir: &'a str) -> Result<DirectoryPaths, &'a str>;
+    fn new(size: usize) -> Self;
+    fn parse<'a>(file: &'a [String], root_dir: &'a str) -> Result<DirectoryPaths, &'a str>;
     fn get_paths(&self) -> Vec<PathBuf>;
 
     //may add functionality to return it as a Vector of type String.
 }
 #[derive(Debug)]
 pub struct DirectoryPaths {
-    paths: Vec<PathBuf>
+    paths: Vec<PathBuf>,
 }
 
 impl Build for DirectoryPaths {
-    
     fn new(size: usize) -> DirectoryPaths {
-        DirectoryPaths {paths: Vec::with_capacity(size)}
+        DirectoryPaths {
+            paths: Vec::with_capacity(size),
+        }
     }
 
     fn get_paths(&self) -> Vec<PathBuf> {
-        return self.paths.clone()
+        self.paths.clone()
     }
 
-    fn parse<'a>(file: &'a Vec<String>, root_dir: &'a str) -> Result<DirectoryPaths, &'a str> {
-       let mut paths: DirectoryPaths = DirectoryPaths::new(file.len());
-       let mut current_path: PathBuf = PathBuf::new(); current_path.push(root_dir.to_owned());
-       let mut current_depth: isize = -1;
+    fn parse<'a>(file: &'a [String], root_dir: &'a str) -> Result<DirectoryPaths, &'a str> {
+        let mut paths: DirectoryPaths = DirectoryPaths::new(file.len());
+        let mut current_path: PathBuf = PathBuf::new();
+        current_path.push(root_dir);
+        let mut current_depth: isize = -1;
 
-       //remove the last element of the file variable and render file variable immutable.
-       let mut file = file.clone(); file.pop(); let file = file;
+        //remove the last element of the file variable and render file variable immutable.
+        let mut file = file.to_owned();
+        file.pop();
+        let file = file;
 
+        for line in file {
+            //check depth of the line
+            //
+            //determine based on depth to move forwards/hold/backwards
+            //
+            let mut new_depth: isize = 0;
+            for chr in line.chars() {
+                if chr == '/' {
+                    new_depth += 1;
+                } else {
+                    break;
+                }
+            }
 
-       for line in file {
-           //check depth of the line
-           //
-           //determine based on depth to move forwards/hold/backwards
-           //
-           let mut new_depth: isize = 0;
-           for chr in line.chars() {
-               if chr == '/' {
-                   new_depth += 1;
-               }else {
-                   break;
-               }
-           }
+            match new_depth.cmp(&current_depth) {
+                std::cmp::Ordering::Less => {
+                    //push the current file path to the paths variable
+                    paths.paths.push(current_path.clone());
 
-           //forward
-           if new_depth > current_depth {
-               current_path.push(line[new_depth as usize..].to_owned());
-           }
-
-           //hold
-           else if current_depth == new_depth {
-               paths.paths.push(current_path.clone());
-               current_path.pop();
-               current_path.push(line[new_depth as usize..].to_owned());
-           }
-
-           //backwards
-           else if new_depth < current_depth {
-               //push the current file path to the paths variable
-               paths.paths.push(current_path.clone());
-
-               //determine using the current depth how many times to pop the current_path variable
-               for _ in 0..(current_depth-new_depth+1) {
-                   current_path.pop();
-               }
-               current_path.push(line[new_depth as usize..].to_owned());
-           }
-           current_depth = new_depth;
-       }
+                    //determine using the current depth how many times to pop the current_path variable
+                    for _ in 0..(current_depth - new_depth + 1) {
+                        current_path.pop();
+                    }
+                    current_path.push(&line[new_depth as usize..]);
+                }
+                std::cmp::Ordering::Equal => {
+                    paths.paths.push(current_path.clone());
+                    current_path.pop();
+                    current_path.push(&line[new_depth as usize..]);
+                }
+                std::cmp::Ordering::Greater => {
+                    current_path.push(&line[new_depth as usize..]);
+                }
+            }
+            current_depth = new_depth;
+        }
         paths.paths.push(current_path.clone());
 
-    Ok(paths)
+        Ok(paths)
     }
 }

--- a/src/file_parse.rs
+++ b/src/file_parse.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, usize};
+use std::{cmp::Ordering, path::PathBuf, usize};
 
 pub trait Build {
     fn new(size: usize) -> Self;
@@ -44,7 +44,7 @@ impl Build for DirectoryPaths {
             }
 
             match new_depth.cmp(&current_depth) {
-                std::cmp::Ordering::Less => {
+                Ordering::Less => {
                     //push the current file path to the paths variable
                     paths.paths.push(current_path.clone());
 
@@ -54,12 +54,12 @@ impl Build for DirectoryPaths {
                     }
                     current_path.push(&line[new_depth as usize..]);
                 }
-                std::cmp::Ordering::Equal => {
+                Ordering::Equal => {
                     paths.paths.push(current_path.clone());
                     current_path.pop();
                     current_path.push(&line[new_depth as usize..]);
                 }
-                std::cmp::Ordering::Greater => {
+                Ordering::Greater => {
                     current_path.push(&line[new_depth as usize..]);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,15 @@ pub struct Config {
 
 impl Config {
     pub fn new(args: &[String]) -> Result<Config, &str> {
-        
         let input_file: String = args[1].clone();
         let output_dir: String = args[2].clone();
         let execution_path: String = env::current_dir().unwrap().display().to_string();
-        
-        Ok(Config {input_file, output_dir, execution_path})
+
+        Ok(Config {
+            input_file,
+            output_dir,
+            execution_path,
+        })
     }
 }
 //Code That can in future be used to make the program more abstract and extensible
@@ -51,5 +54,5 @@ impl Tree for Directory {
         Ok(true)
     }
 
-    
-}*/ 
+
+}*/

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,32 @@
-use std::{env, fs, process};
 use dirby::Config;
+use std::{env, fs, process};
 mod file_checks;
 mod file_parse;
 use file_parse::{Build, DirectoryPaths};
 mod directory_construction;
 
 fn main() {
-    
     //collect environment arguments
     //TODO! check the parsed root directory for illegal characters
     let args: Vec<String> = env::args().collect();
 
     let config: Config = Config::new(&args).unwrap();
 
-
     //read input file.
-    let file_lines: String = fs::read_to_string(config.input_file).expect("Cannot find the specified file. Please check the file name and path.");
+    let file_lines: String = fs::read_to_string(config.input_file)
+        .expect("Cannot find the specified file. Please check the file name and path.");
 
     //check the file is valid
     if !file_checks::is_valid_file(&file_lines) {
         process::exit(1);
     }
 
-    
     let file_lines: Vec<String> = file_lines.split('\n').map(|x| x.to_owned()).collect();
 
-    let file_lines = file_lines.iter().map(|x| x.trim().to_owned()).collect();
+    let file_lines = file_lines
+        .iter()
+        .map(|x| x.trim().to_owned())
+        .collect::<Vec<String>>();
 
     let dir_paths: DirectoryPaths = DirectoryPaths::parse(&file_lines, &config.output_dir).unwrap();
 
@@ -34,9 +35,4 @@ fn main() {
     if builder_result.0.is_err() {
         eprintln!("Directory Construction Error: an error occurred while trying to build the directories\nthis likely because the program does not have permission to access the parsed directory,\nor the program attempted to create a folder with an illegal name.\n>Details:\n--->error: {}\n--->occurred when creating: {}", builder_result.0.unwrap_err(), builder_result.1);
     }
-
-
-
-
 }
-


### PR DESCRIPTION
I applied all the lints that were suggested by clippy (the in-built rust linter). I also formatted using rustfmt, the in-built rust formatter (comes with cargo; as does clippy). 

I also fixed a bug where the last line of the file was getting skipped. This was usually OK, but if there was no trailing newline in the file, this would result in a folder getting skipped. Just removing the line that pops the last line of the file fixed the bug, as having empty line in the list seems to work absolutely fine (on windows at least).

The three main changes that were suggested by the linter were the following:
* Refactor lines 50-71 of file_parse.rs to use a match statement rather than chained if statements. https://rust-lang.github.io/rust-clippy/master/index.html#/comparison_chain
* Remove uses of `&String` and `&Vec<...>` in function parameters, since these do not provide any advantage over `&str` and `&[...]` respectively; and using `&str` and `&[...]` gives the caller of the function more flexibility. https://rust-lang.github.io/rust-clippy/master/index.html#/ptr_arg
* Remove unnecessary calls of `.to_owned()` when it wasn't needed. https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_to_owned